### PR TITLE
fix: build_pointcloud function bug which resulted in permament IOError

### DIFF
--- a/python/build_pointcloud.py
+++ b/python/build_pointcloud.py
@@ -74,6 +74,9 @@ def build_pointcloud(lidar_dir, poses_file, extrinsics_dir, start_time, end_time
         # sensor is VO, which is located at the main vehicle frame
         poses = interpolate_vo_poses(poses_file, timestamps, origin_time)
 
+    # this is required because timestamps array changed in interpolate_poses() function from interpolate_poses.py
+    timestamps = timestamps[1:]
+
     pointcloud = np.array([[0], [0], [0], [0]])
     if lidar == 'ldmrs':
         reflectance = None


### PR DESCRIPTION
This PR fixes the issue with build_pointcloud function which resulted in incorrect ```OSError: Could not find scan files for given time range in directory <lidar_dir>```. #33 